### PR TITLE
Fixed unintended recoloring of rows

### DIFF
--- a/moodleMenu.user.js
+++ b/moodleMenu.user.js
@@ -41,6 +41,7 @@
 
         let divCourseMenuList = document.createElement("div")
         divCourseMenuList.style.overflow = "auto"
+        divCourseMenuList.style.backgroundColor = "white"
         divCourseMenuList.setAttribute("id", "simpleList");
         divCourseMenuList.classList.add("list-group");
         divCourseMenu.appendChild(divCourseMenuList)


### PR DESCRIPTION
Fixes the gray background for each row that has been hovered over once
Example of the error:
![image](https://github.com/HSE-Codes/tampermonkey-moodle-menu-extension/assets/46843360/476aef57-72e5-417c-a9e5-3ef0fbd17810)

---
New 
![image](https://github.com/HSE-Codes/tampermonkey-moodle-menu-extension/assets/46843360/5a98f49c-47dc-4d73-9bc7-a997b6dd28e0)
